### PR TITLE
fixed app.post db.song instead of db.Song

### DIFF
--- a/routes/apiRoutes.js
+++ b/routes/apiRoutes.js
@@ -22,14 +22,20 @@ module.exports = function (app) {
     });
   });
 
+  app.get("/api/songs", function (req, res) {
+    db.song.findAll({}).then(function (results) {//consider changing this variable to Song
+      res.json(results);
+    });
+  });
+
   app.post("/api/songs", function (req, res) {
     console.log("New Song:");
     console.log(req.body);
-    db.Song.create({
+    db.song.create({//consider changing this variable to Song instead of song
       deezerID: req.body.deezerID,
       artistName: req.body.artistName,
       songName: req.body.songName,
-      songURL: req.body.SongURL,
+      songURL: req.body.songURL,
       thumbnail: req.body.thumbnail,
       upvote: 0
     }).then(function (results) {


### PR DESCRIPTION
Fixed the issue with app.post not posting a song to api/songs after clicking on a search result. The issue was just db.Song should have been db.song (apiRoutes.js lines 26 and 34). Now the songs can be added to the api and sync with sequelize/mysql. 

Still need to make sure added songs get associated with their respective rooms so that value in the last column of the songs table can get updated in mysql.