### PR TITLE
changed album size on phone screens, changed volume background on phone

### DIFF
--- a/public/styles/styles.css
+++ b/public/styles/styles.css
@@ -664,4 +664,13 @@ input[type="range"] {
       padding-top: 0;
   }
 
+  .current-album {
+    height: 40px;
+    width: 40px;
+  }
+
+  #volume {
+    background-color: #2c3437;
+  }
+
 }

--- a/views/room.handlebars
+++ b/views/room.handlebars
@@ -27,7 +27,7 @@
             </div>
 
             <div id="user-info">
-                <div id="welcome-box">Welcome <span id="welcome-user">guest</span>! You're in room: {{room}}</div>
+                <div id="welcome-box">Welcome <span id="welcome-user">guest</span>! You're in: {{room}}</div>
             </div>
 
         </div>


### PR DESCRIPTION
Made some minor layout changes. I changed the album artwork size for small screens. On my browser, the smallest width of a display possible still showed a square album, however on my small-screened phone, the album artwork was taller than it was wide. I can't tell if my fix will sort the problem out (only able to check this issue when I visit the deployed version on my phone).

Also changed the background of the volume bar for smaller screens. Since the header is a slight gradient, the new place of the volume bar on smaller screens has a slightly different hue than the desktop version and where it is placed on larger displays.

Edited welcome message to "welcome to: room1" (instead of "welcome to room: room1")